### PR TITLE
초기 환경 설정

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+### Description
+
+
+### Trouble Shooting
+
+
+### ETC

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:11
+
+COPY build/libs/mileage-0.0.1-SNAPSHOT.jar mileageapi.jar
+
+ENTRYPOINT ["java", "-jar", "/mileageapi.jar"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# triple
+# 트리플여행자 클럽 마일리지 서비스
+
+### 실행 방법
+1) git clone
+2) docker-compose up -d
+
+### 종료
+1) docker-compose down

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,10 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'mysql:mysql-connector-java'
+
+    testImplementation 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "3.8"
+services:
+  mysqldb:
+    platform: linux/x86_64 # M1 MAC인 경우
+    image: "mysql:5.7"
+    restart: always
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_DATABASE: "mileage"
+      MYSQL_USER: "test"
+      MYSQL_PASSWORD: "test"
+      MYSQL_ROOT_PASSWORD: "test"
+  server:
+    build: .
+    restart: always
+    ports:
+      - 8080:8080
+    environment:
+      SPRING_DATASOURCE_URL: "jdbc:mysql://mysqldb:3306/mileage?useSSL=false&serverTimezone=UTC&characterEncoding=utf8"
+      SPRING_DATASOURCE_USERNAME: "test"
+      SPRING_DATASOURCE_PASSWORD: "test"
+    depends_on:
+      - mysqldb

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,22 @@
+spring:
+  datasource:
+    # docker run --platform linux/amd64 -p 13306:3306 --name mysql_dev -e MYSQL_ROOT_PASSWORD=dev -e MYSQL_DATABASE=dev -e MYSQL_USER=dev -e MYSQL_PASSWORD=dev -d mysql
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:13306/dev?useSSL=false&serverTimezone=UTC&characterEncoding=utf8
+    username: dev
+    password: dev
+  jpa:
+    properties:
+      hibernate:
+        format_sql: true
+    show-sql: true
+    hibernate:
+      ddl-auto: create-drop
+    open-in-view: false
+logging:
+  level:
+    org:
+      hibernate:
+        type:
+          descriptor:
+            sql: TRACE

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    active: "dev"


### PR DESCRIPTION
### Description
- pr 템플릿 설정
- 개발 환경 mysql 설정
- docker-compose를 통해 바로 실행해 볼 수 있는 환경 세팅


### Trouble Shooting
1. docker를 사용하여 mysql을 설치할 때 M1의 경우는 `platform: linux/x86_64` 옵션을 넣어줘야한다.
2. docker-compose.yml 파일 작성시 url, 유저이름, 비밀번호 등에 ""를 적어주지 않으니까 access denied 등의 오류 발생


### ETC
