### PR TITLE
초기 도메인 구조 설계

### DIFF
--- a/src/main/java/com/triple/mileage/event/domain/Event.java
+++ b/src/main/java/com/triple/mileage/event/domain/Event.java
@@ -1,0 +1,27 @@
+package com.triple.mileage.event.domain;
+
+import java.util.UUID;
+import javax.persistence.*;
+
+import com.triple.mileage.review.domain.Review;
+
+import org.hibernate.annotations.GenericGenerator;
+
+@Entity
+public class Event {
+
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID id;
+
+    @Enumerated(EnumType.STRING)
+    private EventType type;
+
+    @Enumerated(EnumType.STRING)
+    private EventAction action;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Review review;
+}

--- a/src/main/java/com/triple/mileage/event/domain/EventAction.java
+++ b/src/main/java/com/triple/mileage/event/domain/EventAction.java
@@ -1,0 +1,5 @@
+package com.triple.mileage.event.domain;
+
+public enum EventAction {
+    ADD, MOD, DELETE
+}

--- a/src/main/java/com/triple/mileage/event/domain/EventType.java
+++ b/src/main/java/com/triple/mileage/event/domain/EventType.java
@@ -1,0 +1,5 @@
+package com.triple.mileage.event.domain;
+
+public enum EventType {
+    REVIEW
+}

--- a/src/main/java/com/triple/mileage/place/domain/Place.java
+++ b/src/main/java/com/triple/mileage/place/domain/Place.java
@@ -1,0 +1,19 @@
+package com.triple.mileage.place.domain;
+
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import org.hibernate.annotations.GenericGenerator;
+
+@Entity
+public class Place {
+
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID id;
+}

--- a/src/main/java/com/triple/mileage/review/domain/Review.java
+++ b/src/main/java/com/triple/mileage/review/domain/Review.java
@@ -1,0 +1,33 @@
+package com.triple.mileage.review.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import javax.persistence.*;
+
+import com.triple.mileage.place.domain.Place;
+import com.triple.mileage.user.domain.User;
+
+import org.hibernate.annotations.GenericGenerator;
+
+@Entity
+public class Review {
+
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID id;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Place place;
+
+    @OneToMany(mappedBy = "review")
+    private List<ReviewImage> reviewImages = new ArrayList<>();
+
+}

--- a/src/main/java/com/triple/mileage/review/domain/ReviewImage.java
+++ b/src/main/java/com/triple/mileage/review/domain/ReviewImage.java
@@ -1,0 +1,19 @@
+package com.triple.mileage.review.domain;
+
+import java.util.UUID;
+import javax.persistence.*;
+
+import org.hibernate.annotations.GenericGenerator;
+
+@Entity
+public class ReviewImage {
+
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Review review;
+}

--- a/src/main/java/com/triple/mileage/user/domain/User.java
+++ b/src/main/java/com/triple/mileage/user/domain/User.java
@@ -1,0 +1,21 @@
+package com.triple.mileage.user.domain;
+
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import org.hibernate.annotations.GenericGenerator;
+
+@Entity
+public class User {
+
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID id;
+
+    private int point;
+}


### PR DESCRIPTION
### Description
요구사항에 맞게 초기 도메인 구조 설계

### Trouble Shooting
BINARY(16)으로 설정해주지 않으면 BINARY(255)로 설정되어 남는 공간을 0으로 채워넣게 동작한다. 
그래서 기존 UUID로 조회요청시 값을 찾을수 없게 되어 null로 표기된다.

### ETC
