### PR TITLE
testcontainers 사용하여 테스트 환경 mysql로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,11 +27,13 @@ dependencies {
 
     implementation 'com.google.guava:guava:30.1.1-jre'
 
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-restassured'
     testImplementation 'io.rest-assured:rest-assured:4.4.0'
     testImplementation 'com.h2database:h2'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.testcontainers:junit-jupiter:1.17.3'
+    testImplementation "org.testcontainers:mysql:1.17.3"
 }
 
 tasks.named('test') {

--- a/src/test/java/com/triple/mileage/acceptance/AcceptanceTest.java
+++ b/src/test/java/com/triple/mileage/acceptance/AcceptanceTest.java
@@ -10,6 +10,8 @@ import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -17,10 +19,15 @@ import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.specification.RequestSpecification;
 
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.documentationConfiguration;
 
+@Testcontainers
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
@@ -31,6 +38,10 @@ public class AcceptanceTest {
 
     @Autowired
     private DatabaseCleaner cleaner;
+
+    @Container
+    static MySQLContainer mySQLContainer = new MySQLContainer("mysql:8.0.22")
+            .withDatabaseName("testdb");
 
     protected RequestSpecification spec;
 

--- a/src/test/java/com/triple/mileage/util/DatabaseCleaner.java
+++ b/src/test/java/com/triple/mileage/util/DatabaseCleaner.java
@@ -33,12 +33,12 @@ public class DatabaseCleaner implements InitializingBean {
     @Transactional
     public void execute() {
         entityManager.flush();
-        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+        entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 0").executeUpdate();
 
         for (String tableName : tableNames) {
             entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
         }
 
-        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+        entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate();
     }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,18 +1,12 @@
 spring:
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
   datasource:
-    url: jdbc:h2:mem:testdb
-    username: sa
+    url: jdbc:tc:mysql:8.0.22:///testdb
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
   jpa:
     properties:
       hibernate:
         format_sql: true
     show-sql: true
-    hibernate:
-      ddl-auto: create-drop
     open-in-view: false
 logging:
   level:

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="INFO"/>
+    <logger name="com.github.dockerjava" level="WARN"/>
+</configuration>


### PR DESCRIPTION
### Description
- 운영 환경과 유사한 환경에서 테스트하기 위해 테스트환경을 h2 데이터베이스에서 mysql로 변경
- testcontainers의 debug 로그가 너무 많이 보여 logback-test.xml 을 추가하여 info 레벨의 로그만 보이도록 설정

### Trouble Shooting
데이터베이스 초기화 작업을 해줄때 제약조건을 무효화한 후 각 테이블을 turncate 해주고 있는데 문법에러 발생.
- 기존 h2 사용시 제약조건 무효화 쿼리는 `SET REFERENTIAL_INTEGRITY FALSE`였는데 mysql 문법은 `SET FOREIGN_KEY_CHECKS = 0`였다. 해당 부분을 바꿔주니 정상동작

### ETC
- h2를 사용하는 것 보다 처음 컨테이너를 띄우는 곳에 시간이 많이 소요된다. 운영환경과 유사한 환경에서 테스트하기 위한 트레이드 오프라고 생각한다.