### PR TITLE
포인트 적립 API 구현 (리뷰 수정시 발생)

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -25,6 +25,21 @@
 }
 ```
 
+== Review API
+
+=== 리뷰 수정 API(포인트 수정 API 전에 리뷰가 수정되어야 함)
+==== Request
+|===
+| 값 | 타입 | 필수 | 설명
+| id | String | true | 바꿀 리뷰 uuid(pathVariable)
+| content | String | true | 바꿀 리뷰 내용
+| attachedPhotoIds | Array | true | 바꿀 리뷰 이미지
+|===
+include::{snippets}/ReviewAcceptanceTest/updatePoint/http-request.adoc[]
+
+==== Response
+include::{snippets}/ReviewAcceptanceTest/updatePoint/http-response.adoc[]
+
 == Event API
 
 === 포인트 적립 API

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -27,7 +27,8 @@
 
 == Event API
 
-=== 포인트 적립 이벤트 API(리뷰 생성시)
+=== 포인트 적립 API
+
 ==== Request
 |===
 | 값 | 타입 | 필수 | 설명
@@ -39,7 +40,11 @@
 | userId | String | true | 리뷰 작성 유저 uuid
 | placeId | String | true | 리뷰가 작성된 장소 uuid
 |===
+===== 포인트 적립 이벤트 API(리뷰 생성시)
 include::{snippets}/EventAcceptanceTest/increasePoint/http-request.adoc[]
+
+===== 포인트 수정 이벤트 API(리뷰 수정시)
+include::{snippets}/EventAcceptanceTest/updatePoint/http-request.adoc[]
 
 ==== Response
 ===== 성공

--- a/src/main/java/com/triple/mileage/event/application/adapter/IncreasePointEventAdapter.java
+++ b/src/main/java/com/triple/mileage/event/application/adapter/IncreasePointEventAdapter.java
@@ -4,11 +4,17 @@ import com.triple.mileage.event.application.eventexecution.EventExecution;
 import com.triple.mileage.event.application.eventexecution.IncreasePointEvent;
 import com.triple.mileage.event.domain.EventAction;
 import com.triple.mileage.event.domain.EventType;
+import com.triple.mileage.history.domain.PointHistoryRepository;
 
 import org.springframework.stereotype.Component;
 
 @Component
 public class IncreasePointEventAdapter implements EventAdapter {
+    private final PointHistoryRepository pointHistoryRepository;
+
+    public IncreasePointEventAdapter(PointHistoryRepository pointHistoryRepository) {
+        this.pointHistoryRepository = pointHistoryRepository;
+    }
 
     @Override
     public boolean supports(EventType type, EventAction action) {
@@ -17,6 +23,6 @@ public class IncreasePointEventAdapter implements EventAdapter {
 
     @Override
     public EventExecution getEventExecution() {
-        return new IncreasePointEvent();
+        return new IncreasePointEvent(pointHistoryRepository);
     }
 }

--- a/src/main/java/com/triple/mileage/event/application/adapter/UpdatePointEventAdapter.java
+++ b/src/main/java/com/triple/mileage/event/application/adapter/UpdatePointEventAdapter.java
@@ -1,0 +1,28 @@
+package com.triple.mileage.event.application.adapter;
+
+import com.triple.mileage.event.application.eventexecution.EventExecution;
+import com.triple.mileage.event.application.eventexecution.UpdatePointEvent;
+import com.triple.mileage.event.domain.EventAction;
+import com.triple.mileage.event.domain.EventType;
+import com.triple.mileage.history.domain.PointHistoryRepository;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class UpdatePointEventAdapter implements EventAdapter {
+    private final PointHistoryRepository pointHistoryRepository;
+
+    public UpdatePointEventAdapter(PointHistoryRepository pointHistoryRepository) {
+        this.pointHistoryRepository = pointHistoryRepository;
+    }
+
+    @Override
+    public boolean supports(EventType type, EventAction action) {
+        return EventType.REVIEW.equals(type) && EventAction.MOD.equals(action);
+    }
+
+    @Override
+    public EventExecution getEventExecution() {
+        return new UpdatePointEvent(pointHistoryRepository);
+    }
+}

--- a/src/main/java/com/triple/mileage/event/application/eventexecution/IncreasePointEvent.java
+++ b/src/main/java/com/triple/mileage/event/application/eventexecution/IncreasePointEvent.java
@@ -1,17 +1,30 @@
 package com.triple.mileage.event.application.eventexecution;
 
+import com.triple.mileage.history.domain.PointHistory;
+import com.triple.mileage.history.domain.PointHistoryRepository;
 import com.triple.mileage.place.domain.Place;
+import com.triple.mileage.review.domain.PointType;
 import com.triple.mileage.review.domain.Review;
 import com.triple.mileage.user.domain.User;
 
 public class IncreasePointEvent implements EventExecution {
+    private final PointHistoryRepository pointHistoryRepository;
+
+    public IncreasePointEvent(PointHistoryRepository pointHistoryRepository) {
+        this.pointHistoryRepository = pointHistoryRepository;
+    }
 
     @Override
     public void execute(User user, Place place, Review review) {
         int point = review.getPoint();
         user.increasePoint(point);
+        PointHistory contentHistory = new PointHistory(user, review, PointType.CONTENT, point);
+        pointHistoryRepository.save(contentHistory);
+
         if (place.isFirstReview()) {
             user.increasePoint(1);
+            PointHistory bonusHistory = new PointHistory(user, review, PointType.BONUS, 1);
+            pointHistoryRepository.save(bonusHistory);
         }
     }
 }

--- a/src/main/java/com/triple/mileage/event/application/eventexecution/UpdatePointEvent.java
+++ b/src/main/java/com/triple/mileage/event/application/eventexecution/UpdatePointEvent.java
@@ -1,5 +1,7 @@
 package com.triple.mileage.event.application.eventexecution;
 
+import java.util.List;
+
 import com.triple.mileage.history.domain.PointHistory;
 import com.triple.mileage.history.domain.PointHistoryRepository;
 import com.triple.mileage.place.domain.Place;

--- a/src/main/java/com/triple/mileage/event/application/eventexecution/UpdatePointEvent.java
+++ b/src/main/java/com/triple/mileage/event/application/eventexecution/UpdatePointEvent.java
@@ -1,0 +1,40 @@
+package com.triple.mileage.event.application.eventexecution;
+
+import com.triple.mileage.history.domain.PointHistory;
+import com.triple.mileage.history.domain.PointHistoryRepository;
+import com.triple.mileage.place.domain.Place;
+import com.triple.mileage.review.domain.PointType;
+import com.triple.mileage.review.domain.Review;
+import com.triple.mileage.user.domain.User;
+
+public class UpdatePointEvent implements EventExecution {
+    private final PointHistoryRepository pointHistoryRepository;
+
+    public UpdatePointEvent(PointHistoryRepository pointHistoryRepository) {
+        this.pointHistoryRepository = pointHistoryRepository;
+    }
+
+    @Override
+    public void execute(User user, Place place, Review review) {
+        int originalPoint = user.getPoint();
+        int curPoint = 0;
+
+        user.initPoint();
+
+        boolean isBonus = pointHistoryRepository.existsByUserAndReviewAndTypeEquals(user, review, PointType.BONUS);
+        if (isBonus) {
+            user.increasePoint(1);
+            curPoint++;
+        }
+
+        int point = review.getPoint();
+        user.increasePoint(point);
+        curPoint += point;
+
+        int diff = curPoint - originalPoint;
+        if (diff != 0) {
+            PointHistory history = new PointHistory(user, review, PointType.CONTENT, diff);
+            pointHistoryRepository.save(history);
+        }
+    }
+}

--- a/src/main/java/com/triple/mileage/history/domain/PointHistory.java
+++ b/src/main/java/com/triple/mileage/history/domain/PointHistory.java
@@ -1,0 +1,41 @@
+package com.triple.mileage.history.domain;
+
+import java.util.UUID;
+import javax.persistence.*;
+
+import com.triple.mileage.review.domain.PointType;
+import com.triple.mileage.review.domain.Review;
+import com.triple.mileage.user.domain.User;
+
+import org.hibernate.annotations.GenericGenerator;
+
+@Entity(name = "point_history")
+public class PointHistory {
+
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Review review;
+
+    @Enumerated(EnumType.STRING)
+    private PointType type;
+
+    private int point;
+
+    protected PointHistory() {
+    }
+
+    public PointHistory(User user, Review review, PointType type, int point) {
+        this.user = user;
+        this.review = review;
+        this.type = type;
+        this.point = point;
+    }
+}

--- a/src/main/java/com/triple/mileage/history/domain/PointHistoryRepository.java
+++ b/src/main/java/com/triple/mileage/history/domain/PointHistoryRepository.java
@@ -1,0 +1,13 @@
+package com.triple.mileage.history.domain;
+
+import java.util.UUID;
+
+import com.triple.mileage.review.domain.PointType;
+import com.triple.mileage.review.domain.Review;
+import com.triple.mileage.user.domain.User;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PointHistoryRepository extends JpaRepository<PointHistory, UUID> {
+    boolean existsByUserAndReviewAndTypeEquals(User user, Review review, PointType type);
+}

--- a/src/main/java/com/triple/mileage/review/application/ReviewService.java
+++ b/src/main/java/com/triple/mileage/review/application/ReviewService.java
@@ -1,9 +1,13 @@
 package com.triple.mileage.review.application;
 
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import com.triple.mileage.exception.review.NoSuchReviewException;
+import com.triple.mileage.review.application.dto.ReviewRequestDto;
 import com.triple.mileage.review.domain.Review;
+import com.triple.mileage.review.domain.ReviewImage;
 import com.triple.mileage.review.domain.ReviewRepository;
 
 import org.springframework.stereotype.Service;
@@ -21,5 +25,16 @@ public class ReviewService {
     public Review findById(UUID reviewId) {
         return reviewRepository.findById(reviewId)
                                .orElseThrow(NoSuchReviewException::new);
+    }
+
+    @Transactional
+    public void update(ReviewRequestDto requestDto) {
+        Review review = findById(requestDto.getId());
+
+        List<ReviewImage> reviewImages = requestDto.getAttachedPhotoIds().stream()
+                                              .map(ReviewImage::new)
+                                              .collect(Collectors.toList());
+
+        review.update(requestDto.getContent(), reviewImages);
     }
 }

--- a/src/main/java/com/triple/mileage/review/application/dto/ReviewRequestDto.java
+++ b/src/main/java/com/triple/mileage/review/application/dto/ReviewRequestDto.java
@@ -1,0 +1,29 @@
+package com.triple.mileage.review.application.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class ReviewRequestDto {
+    private UUID id;
+    private String content;
+    private List<UUID> attachedPhotoIds;
+
+    public ReviewRequestDto(UUID id, String content, List<UUID> attachedPhotoIds) {
+        this.id = id;
+        this.content = content;
+        this.attachedPhotoIds = attachedPhotoIds;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public List<UUID> getAttachedPhotoIds() {
+        return attachedPhotoIds;
+    }
+}

--- a/src/main/java/com/triple/mileage/review/domain/PointType.java
+++ b/src/main/java/com/triple/mileage/review/domain/PointType.java
@@ -1,0 +1,5 @@
+package com.triple.mileage.review.domain;
+
+public enum PointType {
+    CONTENT, BONUS
+}

--- a/src/main/java/com/triple/mileage/review/domain/Review.java
+++ b/src/main/java/com/triple/mileage/review/domain/Review.java
@@ -57,6 +57,12 @@ public class Review {
         return point;
     }
 
+    public void update(String content, List<ReviewImage> reviewImages) {
+        this.content = content;
+        this.reviewImages = reviewImages;
+        reviewImages.forEach(image -> image.belongTo(this));
+    }
+
     public UUID getId() {
         return id;
     }

--- a/src/main/java/com/triple/mileage/review/domain/ReviewImage.java
+++ b/src/main/java/com/triple/mileage/review/domain/ReviewImage.java
@@ -21,6 +21,13 @@ public class ReviewImage {
         this.review = review;
     }
 
+    public ReviewImage() {
+    }
+
+    public ReviewImage(UUID id) {
+        this.id = id;
+    }
+
     public UUID getId() {
         return id;
     }

--- a/src/main/java/com/triple/mileage/review/presentation/ReviewRestController.java
+++ b/src/main/java/com/triple/mileage/review/presentation/ReviewRestController.java
@@ -1,0 +1,29 @@
+package com.triple.mileage.review.presentation;
+
+import java.util.UUID;
+
+import com.triple.mileage.review.application.ReviewService;
+import com.triple.mileage.review.application.dto.ReviewRequestDto;
+import com.triple.mileage.review.presentation.dto.ReviewRequest;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ReviewRestController {
+    private final ReviewService reviewService;
+
+    public ReviewRestController(ReviewService reviewService) {
+        this.reviewService = reviewService;
+    }
+
+    @PatchMapping("/reviews/{id}")
+    public ResponseEntity<Void> updateReview(@PathVariable UUID id, @RequestBody ReviewRequest request) {
+        ReviewRequestDto requestDto = new ReviewRequestDto(id, request.getContent(), request.getAttachedPhotoIds());
+        reviewService.update(requestDto);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/triple/mileage/review/presentation/dto/ReviewRequest.java
+++ b/src/main/java/com/triple/mileage/review/presentation/dto/ReviewRequest.java
@@ -1,0 +1,26 @@
+package com.triple.mileage.review.presentation.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class ReviewRequest {
+    private String content;
+    private List<UUID> attachedPhotoIds = new ArrayList<>();
+
+    public ReviewRequest() {
+    }
+
+    public ReviewRequest(String content, List<UUID> attachedPhotoIds) {
+        this.content = content;
+        this.attachedPhotoIds = attachedPhotoIds;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public List<UUID> getAttachedPhotoIds() {
+        return attachedPhotoIds;
+    }
+}

--- a/src/main/java/com/triple/mileage/user/domain/User.java
+++ b/src/main/java/com/triple/mileage/user/domain/User.java
@@ -35,6 +35,10 @@ public class User {
         this.point += point;
     }
 
+    public void initPoint() {
+        this.point = 0;
+    }
+
     public UUID getId() {
         return id;
     }

--- a/src/main/resources/db/migration/V2__create_point_history.sql
+++ b/src/main/resources/db/migration/V2__create_point_history.sql
@@ -1,0 +1,19 @@
+create table point_history
+(
+    id        BINARY(16) not null,
+    user_id    BINARY(16),
+    review_id    BINARY(16),
+    type      varchar(255),
+    point integer not null,
+    primary key (id)
+);
+
+alter table point_history
+    add constraint fk_point_history_to_user
+        foreign key (user_id)
+            references users (id);
+
+alter table point_history
+    add constraint fk_point_history_to_review
+        foreign key (review_id)
+            references review (id);

--- a/src/test/java/com/triple/mileage/acceptance/event/EventAcceptanceTest.java
+++ b/src/test/java/com/triple/mileage/acceptance/event/EventAcceptanceTest.java
@@ -50,7 +50,7 @@ public class EventAcceptanceTest extends AcceptanceTest {
         List<UUID> photos = review.getReviewImages().stream().map(ReviewImage::getId).collect(Collectors.toList());
 
         EventRequest request = new EventRequest(
-                "review", "add", review.getId(), review.getContent(), photos, user.getId(), place.getId()
+                "REVIEW", "ADD", review.getId(), review.getContent(), photos, user.getId(), place.getId()
         );
 
         // when
@@ -71,7 +71,7 @@ public class EventAcceptanceTest extends AcceptanceTest {
         List<UUID> photos = review.getReviewImages().stream().map(ReviewImage::getId).collect(Collectors.toList());
 
         EventRequest request = new EventRequest(
-                "review", "add", review.getId(), review.getContent(), photos, UUID.randomUUID(), place.getId()
+                "REVIEW", "ADD", review.getId(), review.getContent(), photos, UUID.randomUUID(), place.getId()
         );
 
         // when
@@ -92,7 +92,7 @@ public class EventAcceptanceTest extends AcceptanceTest {
         List<UUID> photos = review.getReviewImages().stream().map(ReviewImage::getId).collect(Collectors.toList());
 
         EventRequest request = new EventRequest(
-                "review", "add", review.getId(), review.getContent(), photos, user.getId(), UUID.randomUUID()
+                "REVIEW", "ADD", review.getId(), review.getContent(), photos, user.getId(), UUID.randomUUID()
         );
 
         // when
@@ -113,7 +113,7 @@ public class EventAcceptanceTest extends AcceptanceTest {
         List<UUID> photos = review.getReviewImages().stream().map(ReviewImage::getId).collect(Collectors.toList());
 
         EventRequest request = new EventRequest(
-                "review", "add", UUID.randomUUID(), review.getContent(), photos, user.getId(), place.getId()
+                "REVIEW", "ADD", UUID.randomUUID(), review.getContent(), photos, user.getId(), place.getId()
         );
 
         // when
@@ -134,7 +134,7 @@ public class EventAcceptanceTest extends AcceptanceTest {
         List<UUID> photos = review.getReviewImages().stream().map(ReviewImage::getId).collect(Collectors.toList());
 
         EventRequest request = new EventRequest(
-                "lotto", "add", review.getId(), review.getContent(), photos, user.getId(), place.getId()
+                "lotto", "ADD", review.getId(), review.getContent(), photos, user.getId(), place.getId()
         );
 
         // when
@@ -155,7 +155,7 @@ public class EventAcceptanceTest extends AcceptanceTest {
         List<UUID> photos = review.getReviewImages().stream().map(ReviewImage::getId).collect(Collectors.toList());
 
         EventRequest request = new EventRequest(
-                "review", "read", review.getId(), review.getContent(), photos, user.getId(), place.getId()
+                "REVIEW", "read", review.getId(), review.getContent(), photos, user.getId(), place.getId()
         );
 
         // when
@@ -163,6 +163,27 @@ public class EventAcceptanceTest extends AcceptanceTest {
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    @DisplayName("리뷰 수정시 포인트 수정 이벤트가 발생한다.")
+    void updatePoint() {
+        // given
+        // TODO user, place, review 생성 api가 만들어진다면 repository 호출대신 해당 api 호출로 대체
+        User user = userRepository.save(new User(0));
+        Place place = placeRepository.save(new Place());
+        Review review = reviewRepository.save(new Review("좋아요!", user, place, List.of(new ReviewImage(), new ReviewImage())));
+        List<UUID> photos = review.getReviewImages().stream().map(ReviewImage::getId).collect(Collectors.toList());
+
+        EventRequest request = new EventRequest(
+                "REVIEW", "MOD", review.getId(), review.getContent(), photos, user.getId(), place.getId()
+        );
+
+        // when
+        ExtractableResponse<Response> response = 이벤트_요청(request);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
 
     private ExtractableResponse<Response> 이벤트_요청(EventRequest request) {

--- a/src/test/java/com/triple/mileage/acceptance/review/ReviewAcceptanceTest.java
+++ b/src/test/java/com/triple/mileage/acceptance/review/ReviewAcceptanceTest.java
@@ -1,0 +1,73 @@
+package com.triple.mileage.acceptance.review;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import com.triple.mileage.acceptance.AcceptanceTest;
+import com.triple.mileage.event.presentation.dto.EventRequest;
+import com.triple.mileage.place.domain.Place;
+import com.triple.mileage.place.domain.PlaceRepository;
+import com.triple.mileage.review.domain.Review;
+import com.triple.mileage.review.domain.ReviewImage;
+import com.triple.mileage.review.domain.ReviewRepository;
+import com.triple.mileage.review.presentation.dto.ReviewRequest;
+import com.triple.mileage.user.domain.User;
+import com.triple.mileage.user.domain.UserRepository;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@DisplayName("Review 인수테스트")
+public class ReviewAcceptanceTest extends AcceptanceTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PlaceRepository placeRepository;
+
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @Test
+    @DisplayName("리뷰 수정 API")
+    void updatePoint() {
+        // given
+        // TODO user, place, review 생성 api가 만들어진다면 repository 호출대신 해당 api 호출로 대체
+        User user = userRepository.save(new User(0));
+        Place place = placeRepository.save(new Place());
+        Review review = reviewRepository.save(new Review("좋아요!", user, place, List.of(new ReviewImage(), new ReviewImage())));
+
+        ReviewRequest reviewRequest = new ReviewRequest("너무 좋았습니다!", Collections.emptyList());
+
+        // when
+        ExtractableResponse<Response> response = 리뷰_수정(review.getId(), reviewRequest);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    private ExtractableResponse<Response> 리뷰_수정(UUID id, ReviewRequest request) {
+        return RestAssured.given(spec)
+                          .log().all()
+                          .contentType(APPLICATION_JSON_VALUE)
+                          .body(request)
+                          .when()
+                          .patch("/reviews/" + id)
+                          .then()
+                          .log().all()
+                          .extract();
+    }
+}

--- a/src/test/java/com/triple/mileage/acceptance/review/ReviewAcceptanceTest.java
+++ b/src/test/java/com/triple/mileage/acceptance/review/ReviewAcceptanceTest.java
@@ -3,10 +3,8 @@ package com.triple.mileage.acceptance.review;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import com.triple.mileage.acceptance.AcceptanceTest;
-import com.triple.mileage.event.presentation.dto.EventRequest;
 import com.triple.mileage.place.domain.Place;
 import com.triple.mileage.place.domain.PlaceRepository;
 import com.triple.mileage.review.domain.Review;

--- a/src/test/java/com/triple/mileage/unit/review/ReviewTest.java
+++ b/src/test/java/com/triple/mileage/unit/review/ReviewTest.java
@@ -28,7 +28,7 @@ class ReviewTest {
         // then
         assertThat(point).isEqualTo(0);
     }
-    
+
     @Test
     @DisplayName("Review 내용이 1자 이상이면 1점을 얻는다.")
     void content() {


### PR DESCRIPTION
### Description
포인트 적립 API 구현 (리뷰 수정시 발생)
리뷰 수정 이후 -> 포인트 적립 API가 호출되어야 해서 간단하게 리뷰 수정 API도 함께 추가

### Trouble Shooting
통합테스트시 테스트 메서드마다 같은 트랜잭션으로 묶여 JPA에 의해 값이 제대로 나오지 않은 문제를 EntityManager를 주입받아 flush, clear로 DB에 반영되게 하여 해결함

### ETC
