### PR TITLE
포인트 증감 내역 기록 aop 적용하여 분리

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     ports:
       - 8080:8080
     environment:
-      SPRING_DATASOURCE_URL: "jdbc:mysql://mysqldb:3306/mileage?useSSL=false&serverTimezone=UTC&characterEncoding=utf8"
+      SPRING_DATASOURCE_URL: "jdbc:mysql://mysqldb:3306/mileage?useSSL=false&serverTimezone=UTC&characterEncoding=utf8&allowPublicKeyRetrieval=true"
       SPRING_DATASOURCE_USERNAME: "test"
       SPRING_DATASOURCE_PASSWORD: "test"
     depends_on:

--- a/src/main/java/com/triple/mileage/common/aop/Record.java
+++ b/src/main/java/com/triple/mileage/common/aop/Record.java
@@ -1,0 +1,14 @@
+package com.triple.mileage.common.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.triple.mileage.event.domain.EventAction;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Record {
+    EventAction action();
+}

--- a/src/main/java/com/triple/mileage/common/aop/RecordAspect.java
+++ b/src/main/java/com/triple/mileage/common/aop/RecordAspect.java
@@ -1,0 +1,62 @@
+package com.triple.mileage.common.aop;
+
+import com.triple.mileage.event.domain.EventAction;
+import com.triple.mileage.history.domain.PointHistory;
+import com.triple.mileage.history.domain.PointHistoryRepository;
+import com.triple.mileage.place.domain.Place;
+import com.triple.mileage.review.domain.PointType;
+import com.triple.mileage.review.domain.Review;
+import com.triple.mileage.user.domain.User;
+
+import org.springframework.stereotype.Component;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+
+@Aspect
+@Component
+public class RecordAspect {
+    private final PointHistoryRepository pointHistoryRepository;
+
+    public RecordAspect(PointHistoryRepository pointHistoryRepository) {
+        this.pointHistoryRepository = pointHistoryRepository;
+    }
+
+    @Pointcut(value = "@annotation(record) && args(user, place, review)", argNames = "record,user,place,review")
+    public void recordPointHistory(Record record, User user, Place place, Review review) {}
+
+    @Around(value = "recordPointHistory(record, user, place, review)", argNames = "joinPoint,record,user,place,review")
+    public Object record(ProceedingJoinPoint joinPoint, Record record, User user, Place place, Review review) throws Throwable {
+        int prevBasicPoint = review.getBasicPoint();
+
+        Object result = joinPoint.proceed();
+
+        int curBasicPoint = review.getBasicPoint();
+        int bonusPoint = review.getBonusPoint();
+
+        EventAction action = record.action();
+        if (EventAction.ADD.equals(action)) {
+            record(user, review, PointType.CONTENT, curBasicPoint);
+            record(user, review, PointType.BONUS, bonusPoint);
+        }
+        if (EventAction.MOD.equals(action)) {
+            int diff = curBasicPoint - prevBasicPoint;
+            record(user, review, PointType.CONTENT, diff);
+        }
+        if (EventAction.DELETE.equals(action)) {
+            record(user, review, PointType.CONTENT, prevBasicPoint * -1);
+            record(user, review, PointType.BONUS, bonusPoint * -1);
+        }
+
+        return result;
+    }
+
+    private void record(User user, Review review, PointType type, int point) {
+        if (point != 0) {
+            PointHistory history = new PointHistory(user, review, type, point);
+            pointHistoryRepository.save(history);
+        }
+    }
+}

--- a/src/main/java/com/triple/mileage/event/application/adapter/DecreasePointEventAdapter.java
+++ b/src/main/java/com/triple/mileage/event/application/adapter/DecreasePointEventAdapter.java
@@ -4,16 +4,15 @@ import com.triple.mileage.event.application.eventexecution.DecreasePointEvent;
 import com.triple.mileage.event.application.eventexecution.EventExecution;
 import com.triple.mileage.event.domain.EventAction;
 import com.triple.mileage.event.domain.EventType;
-import com.triple.mileage.history.domain.PointHistoryRepository;
 
 import org.springframework.stereotype.Component;
 
 @Component
 public class DecreasePointEventAdapter implements EventAdapter {
-    private final PointHistoryRepository pointHistoryRepository;
+    private final DecreasePointEvent decreasePointEvent;
 
-    public DecreasePointEventAdapter(PointHistoryRepository pointHistoryRepository) {
-        this.pointHistoryRepository = pointHistoryRepository;
+    public DecreasePointEventAdapter(DecreasePointEvent decreasePointEvent) {
+        this.decreasePointEvent = decreasePointEvent;
     }
 
     @Override
@@ -23,6 +22,6 @@ public class DecreasePointEventAdapter implements EventAdapter {
 
     @Override
     public EventExecution getEventExecution() {
-        return new DecreasePointEvent(pointHistoryRepository);
+        return decreasePointEvent;
     }
 }

--- a/src/main/java/com/triple/mileage/event/application/adapter/IncreasePointEventAdapter.java
+++ b/src/main/java/com/triple/mileage/event/application/adapter/IncreasePointEventAdapter.java
@@ -4,16 +4,15 @@ import com.triple.mileage.event.application.eventexecution.EventExecution;
 import com.triple.mileage.event.application.eventexecution.IncreasePointEvent;
 import com.triple.mileage.event.domain.EventAction;
 import com.triple.mileage.event.domain.EventType;
-import com.triple.mileage.history.domain.PointHistoryRepository;
 
 import org.springframework.stereotype.Component;
 
 @Component
 public class IncreasePointEventAdapter implements EventAdapter {
-    private final PointHistoryRepository pointHistoryRepository;
+    private final IncreasePointEvent increasePointEvent;
 
-    public IncreasePointEventAdapter(PointHistoryRepository pointHistoryRepository) {
-        this.pointHistoryRepository = pointHistoryRepository;
+    public IncreasePointEventAdapter(IncreasePointEvent increasePointEvent) {
+        this.increasePointEvent = increasePointEvent;
     }
 
     @Override
@@ -23,6 +22,6 @@ public class IncreasePointEventAdapter implements EventAdapter {
 
     @Override
     public EventExecution getEventExecution() {
-        return new IncreasePointEvent(pointHistoryRepository);
+        return increasePointEvent;
     }
 }

--- a/src/main/java/com/triple/mileage/event/application/adapter/UpdatePointEventAdapter.java
+++ b/src/main/java/com/triple/mileage/event/application/adapter/UpdatePointEventAdapter.java
@@ -4,16 +4,15 @@ import com.triple.mileage.event.application.eventexecution.EventExecution;
 import com.triple.mileage.event.application.eventexecution.UpdatePointEvent;
 import com.triple.mileage.event.domain.EventAction;
 import com.triple.mileage.event.domain.EventType;
-import com.triple.mileage.history.domain.PointHistoryRepository;
 
 import org.springframework.stereotype.Component;
 
 @Component
 public class UpdatePointEventAdapter implements EventAdapter {
-    private final PointHistoryRepository pointHistoryRepository;
+    private final UpdatePointEvent updatePointEvent;
 
-    public UpdatePointEventAdapter(PointHistoryRepository pointHistoryRepository) {
-        this.pointHistoryRepository = pointHistoryRepository;
+    public UpdatePointEventAdapter(UpdatePointEvent updatePointEvent) {
+        this.updatePointEvent = updatePointEvent;
     }
 
     @Override
@@ -23,6 +22,6 @@ public class UpdatePointEventAdapter implements EventAdapter {
 
     @Override
     public EventExecution getEventExecution() {
-        return new UpdatePointEvent(pointHistoryRepository);
+        return updatePointEvent;
     }
 }

--- a/src/main/java/com/triple/mileage/event/application/eventexecution/DecreasePointEvent.java
+++ b/src/main/java/com/triple/mileage/event/application/eventexecution/DecreasePointEvent.java
@@ -1,37 +1,27 @@
 package com.triple.mileage.event.application.eventexecution;
 
-import com.triple.mileage.history.domain.PointHistory;
-import com.triple.mileage.history.domain.PointHistoryRepository;
+import com.triple.mileage.common.aop.Record;
+import com.triple.mileage.event.domain.EventAction;
 import com.triple.mileage.place.domain.Place;
-import com.triple.mileage.review.domain.PointType;
 import com.triple.mileage.review.domain.Review;
 import com.triple.mileage.user.domain.User;
 
+import org.springframework.stereotype.Component;
+
+@Component
 public class DecreasePointEvent implements EventExecution {
-    private final PointHistoryRepository pointHistoryRepository;
 
-    public DecreasePointEvent(PointHistoryRepository pointHistoryRepository) {
-        this.pointHistoryRepository = pointHistoryRepository;
-    }
-
+    @Record(action = EventAction.DELETE)
     @Override
     public void execute(User user, Place place, Review review) {
         int basicPoint = review.getBasicPoint();
         int bonusPoint = review.getBonusPoint();
         user.decreasePoint(basicPoint + bonusPoint);
         review.initPoint();
-
-        recordPointHistory(user, review, basicPoint, bonusPoint);
     }
 
-    private void recordPointHistory(User user, Review review, int basicPoint, int bonusPoint) {
-        if (basicPoint != 0) {
-            PointHistory history = new PointHistory(user, review, PointType.CONTENT, basicPoint * -1);
-            pointHistoryRepository.save(history);
-        }
-        if (bonusPoint != 0) {
-            PointHistory history = new PointHistory(user, review, PointType.BONUS, bonusPoint * -1);
-            pointHistoryRepository.save(history);
-        }
+    @Override
+    public boolean isSame(EventExecution eventExecution) {
+        return eventExecution instanceof DecreasePointEvent;
     }
 }

--- a/src/main/java/com/triple/mileage/event/application/eventexecution/EventExecution.java
+++ b/src/main/java/com/triple/mileage/event/application/eventexecution/EventExecution.java
@@ -7,4 +7,6 @@ import com.triple.mileage.user.domain.User;
 public interface EventExecution {
 
     void execute(User user, Place place, Review review);
+
+    boolean isSame(EventExecution eventExecution);
 }

--- a/src/main/java/com/triple/mileage/event/application/eventexecution/IncreasePointEvent.java
+++ b/src/main/java/com/triple/mileage/event/application/eventexecution/IncreasePointEvent.java
@@ -1,19 +1,17 @@
 package com.triple.mileage.event.application.eventexecution;
 
-import com.triple.mileage.history.domain.PointHistory;
-import com.triple.mileage.history.domain.PointHistoryRepository;
+import com.triple.mileage.common.aop.Record;
+import com.triple.mileage.event.domain.EventAction;
 import com.triple.mileage.place.domain.Place;
-import com.triple.mileage.review.domain.PointType;
 import com.triple.mileage.review.domain.Review;
 import com.triple.mileage.user.domain.User;
 
+import org.springframework.stereotype.Component;
+
+@Component
 public class IncreasePointEvent implements EventExecution {
-    private final PointHistoryRepository pointHistoryRepository;
 
-    public IncreasePointEvent(PointHistoryRepository pointHistoryRepository) {
-        this.pointHistoryRepository = pointHistoryRepository;
-    }
-
+    @Record(action = EventAction.ADD)
     @Override
     public void execute(User user, Place place, Review review) {
         review.calculatePoint();
@@ -25,17 +23,10 @@ public class IncreasePointEvent implements EventExecution {
         int bonusPoint = review.getBonusPoint();
         user.increasePoint(basicPoint + bonusPoint);
 
-        recordPointHistory(user, review, basicPoint, bonusPoint);
     }
 
-    private void recordPointHistory(User user, Review review, int basicPoint, int bonusPoint) {
-        if (basicPoint != 0) {
-            PointHistory contentHistory = new PointHistory(user, review, PointType.CONTENT, basicPoint);
-            pointHistoryRepository.save(contentHistory);
-        }
-        if (bonusPoint != 0) {
-            PointHistory bonusHistory = new PointHistory(user, review, PointType.BONUS, bonusPoint);
-            pointHistoryRepository.save(bonusHistory);
-        }
+    @Override
+    public boolean isSame(EventExecution eventExecution) {
+        return eventExecution instanceof IncreasePointEvent;
     }
 }

--- a/src/main/java/com/triple/mileage/event/application/eventexecution/UpdatePointEvent.java
+++ b/src/main/java/com/triple/mileage/event/application/eventexecution/UpdatePointEvent.java
@@ -1,19 +1,17 @@
 package com.triple.mileage.event.application.eventexecution;
 
-import com.triple.mileage.history.domain.PointHistory;
-import com.triple.mileage.history.domain.PointHistoryRepository;
+import com.triple.mileage.common.aop.Record;
+import com.triple.mileage.event.domain.EventAction;
 import com.triple.mileage.place.domain.Place;
-import com.triple.mileage.review.domain.PointType;
 import com.triple.mileage.review.domain.Review;
 import com.triple.mileage.user.domain.User;
 
+import org.springframework.stereotype.Component;
+
+@Component
 public class UpdatePointEvent implements EventExecution {
-    private final PointHistoryRepository pointHistoryRepository;
 
-    public UpdatePointEvent(PointHistoryRepository pointHistoryRepository) {
-        this.pointHistoryRepository = pointHistoryRepository;
-    }
-
+    @Record(action = EventAction.MOD)
     @Override
     public void execute(User user, Place place, Review review) {
         int prevBasicPoint = review.getBasicPoint();
@@ -24,15 +22,10 @@ public class UpdatePointEvent implements EventExecution {
 
         int newBasicPoint = review.getBasicPoint();
         user.increasePoint(newBasicPoint);
-
-        recordPointHistory(user, review, prevBasicPoint, newBasicPoint);
     }
 
-    private void recordPointHistory(User user, Review review, int prevBasicPoint, int newBasicPoint) {
-        int diff = newBasicPoint - prevBasicPoint;
-        if (diff != 0) {
-            PointHistory history = new PointHistory(user, review, PointType.CONTENT, diff);
-            pointHistoryRepository.save(history);
-        }
+    @Override
+    public boolean isSame(EventExecution eventExecution) {
+        return eventExecution instanceof UpdatePointEvent;
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -2,7 +2,7 @@ spring:
   datasource:
     # docker run --platform linux/amd64 -p 13306:3306 --name mysql_dev -e MYSQL_ROOT_PASSWORD=dev -e MYSQL_DATABASE=dev -e MYSQL_USER=dev -e MYSQL_PASSWORD=dev -d mysql
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:13306/dev?useSSL=false&serverTimezone=UTC&characterEncoding=utf8
+    url: jdbc:mysql://localhost:13306/dev?useSSL=false&serverTimezone=UTC&characterEncoding=utf8&allowPublicKeyRetrieval=true
     username: dev
     password: dev
   jpa:

--- a/src/test/java/com/triple/mileage/unit/event/DecreasePointTest.java
+++ b/src/test/java/com/triple/mileage/unit/event/DecreasePointTest.java
@@ -4,10 +4,7 @@ import java.util.List;
 import java.util.UUID;
 
 import com.triple.mileage.event.application.eventexecution.DecreasePointEvent;
-import com.triple.mileage.history.domain.PointHistory;
-import com.triple.mileage.history.domain.PointHistoryRepository;
 import com.triple.mileage.place.domain.Place;
-import com.triple.mileage.review.domain.PointType;
 import com.triple.mileage.review.domain.Review;
 import com.triple.mileage.review.domain.ReviewImage;
 import com.triple.mileage.review.domain.ReviewPoint;
@@ -15,19 +12,11 @@ import com.triple.mileage.user.domain.User;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("DecreasePoint 단위 테스트")
-@ExtendWith(MockitoExtension.class)
 public class DecreasePointTest {
-
-    @Mock
-    private PointHistoryRepository pointHistoryRepository;
 
     @Test
     @DisplayName("리뷰를 삭제해서 점수가 초기화 된다.")
@@ -37,9 +26,8 @@ public class DecreasePointTest {
         Place place = new Place(UUID.randomUUID());
         Review review = new Review(UUID.randomUUID(), "좋아요!", user, place,
                 new ReviewPoint(1, 1, 1), List.of(new ReviewImage(UUID.randomUUID()), new ReviewImage(UUID.randomUUID())));
-        PointHistory history = new PointHistory(user, review, PointType.BONUS, 1);
 
-        DecreasePointEvent event = new DecreasePointEvent(pointHistoryRepository);
+        DecreasePointEvent event = new DecreasePointEvent();
 
         // when
         event.execute(user, place, review);

--- a/src/test/java/com/triple/mileage/unit/event/IncreasePointTest.java
+++ b/src/test/java/com/triple/mileage/unit/event/IncreasePointTest.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.UUID;
 
 import com.triple.mileage.event.application.eventexecution.IncreasePointEvent;
-import com.triple.mileage.history.domain.PointHistoryRepository;
 import com.triple.mileage.place.domain.Place;
 import com.triple.mileage.review.domain.Review;
 import com.triple.mileage.review.domain.ReviewImage;
@@ -12,19 +11,11 @@ import com.triple.mileage.user.domain.User;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("IncreasePoint 단위 테스트")
-@ExtendWith(MockitoExtension.class)
 public class IncreasePointTest {
-
-    @Mock
-    private PointHistoryRepository pointHistoryRepository;
 
     @Test
     @DisplayName("내용과 사진을 포함하여 첫번째로 리뷰를 작성하여 3포인트를 얻는다.")
@@ -36,7 +27,7 @@ public class IncreasePointTest {
         Review review = new Review(UUID.randomUUID(), "좋아요!", user, place, List.of(new ReviewImage(), new ReviewImage()));
         place = new Place(placeId, List.of(review));
 
-        IncreasePointEvent event = new IncreasePointEvent(pointHistoryRepository);
+        IncreasePointEvent event = new IncreasePointEvent();
 
         // when
         event.execute(user, place, review);

--- a/src/test/java/com/triple/mileage/unit/event/UpdatePointTest.java
+++ b/src/test/java/com/triple/mileage/unit/event/UpdatePointTest.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.UUID;
 
 import com.triple.mileage.event.application.eventexecution.UpdatePointEvent;
-import com.triple.mileage.history.domain.PointHistoryRepository;
 import com.triple.mileage.place.domain.Place;
 import com.triple.mileage.review.domain.Review;
 import com.triple.mileage.review.domain.ReviewImage;
@@ -13,19 +12,11 @@ import com.triple.mileage.user.domain.User;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("UpdatePoint 단위 테스트")
-@ExtendWith(MockitoExtension.class)
 public class UpdatePointTest {
-
-    @Mock
-    private PointHistoryRepository pointHistoryRepository;
 
     @Test
     @DisplayName("기존 점수 1에서 내용, 사진을 추가하여 3점을 반환한다.")
@@ -36,7 +27,7 @@ public class UpdatePointTest {
         Review review = new Review(UUID.randomUUID(), "좋아요!", user, place,
                 new ReviewPoint(0, 0, 1), List.of(new ReviewImage(UUID.randomUUID()), new ReviewImage(UUID.randomUUID())));
 
-        UpdatePointEvent event = new UpdatePointEvent(pointHistoryRepository);
+        UpdatePointEvent event = new UpdatePointEvent();
 
         // when
         event.execute(user, place, review);


### PR DESCRIPTION
### Description
포인트 증감 내역 기록 aop 적용하여 분리

### Trouble Shooting
aop가 프록시 기반으로 동작하여 내부에서 호출되는 메서드에 포인트컷을 설정해줘도 aop를 타지 못하는 문제가 발생하였다.
이를 처리하기 위해 내부 호출되는 객체를 생성자 주입 받아 내부 호출되는 객체 호출시 프록시 처리된 객체가 로직을 수행하도록 하여 aop를 적용할 수 있었다.

### ETC
